### PR TITLE
enable support for develop and pep517

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,3 +20,9 @@ coverage:
         target: auto
         threshold: 1%
  
+fixes:
+  # reduces pip-installed path to git root and
+  # remove dist-name from setup-installed path
+  - "*/site-packages/::"
+  - "*/site-packages/klepto-*::"
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 # source = klepto
-include = */klepto/*
+include =
+    */klepto/*
 omit = 
     */tests/*
     */info.py
@@ -11,7 +12,14 @@ branch = true
 # data_file = $TRAVIS_BUILD_DIR/.coverage
 # debug = trace
 
+[paths]
+source =
+    klepto
+    */site-packages/klepto*/klepto
+
 [report]
+include =
+    */klepto/*
 exclude_lines =
     pragma: no cover
     raise NotImplementedError

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,7 +15,8 @@ branch = true
 [paths]
 source =
     klepto
-    */site-packages/klepto*/klepto
+    */site-packages/klepto
+    */site-packages/klepto-*/klepto
 
 [report]
 include =

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
 
 # build
 python:
-  version: "3.7"
+  version: "3.9"
   install:
     - method: pip
       path: .

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,4 @@ script:
 
 after_success:
     - if [[ $COVERAGE == "true" ]]; then bash <(curl -s https://codecov.io/bash); else echo ''; fi
+    - if [[ $COVERAGE == "true" ]]; then coverage report; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ matrix:
 
         - python: '3.7'
           env:
-            - COVERAGE="true"
-            - PANDAS="true"
-            - SQLALCHEMY="true"
-            - H5PY="true"
 
         - python: '3.8'
           env:
 
         - python: '3.9'
           env:
+            - COVERAGE="true"
+            - PANDAS="true"
+            - SQLALCHEMY="true"
+            - H5PY="true"
 
         - python: '3.10'
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
     - if [[ $DILL == "master" ]]; then pip install "https://github.com/uqfoundation/dill/archive/master.tar.gz"; fi
 
 install:
-    - python setup.py build && python setup.py install
+    - python -m pip install .
 
 script:
     - for test in tests/__init__.py; do echo $test ; if [[ $COVERAGE == "true" ]]; then coverage run -a $test > /dev/null; else python $test > /dev/null; fi ; done

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include LICENSE
 include README
+include MANIFEST.in
+include pyproject.toml
 include tox.ini
 include tests/*py
 recursive-include docs *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
-include README
+include README*
 include MANIFEST.in
 include pyproject.toml
 include tox.ini

--- a/README.md
+++ b/README.md
@@ -86,6 +86,40 @@ You can get the latest development version with all the shiny new features at:
 If you have a new contribution, please submit a pull request.
 
 
+Installation
+------------
+``klepto`` can be installed with ``pip``::
+
+    $ pip install klepto
+
+To include optional archive backends, such as HDF5 and SQL, in the install::
+
+    $ pip install klepto[archives]
+
+To include optional serializers, such as jsonpickle, in the install::
+
+    $ pip install klepto[crypto]
+
+
+Requirements
+------------
+``klepto`` requires:
+
+* ``python`` (or ``pypy``), **==2.7** or **>=3.7**
+* ``setuptools``, **>=42**
+* ``wheel``, **>=0.1**
+* ``dill``, **>=0.3.4**
+* ``pox``, **>=0.3.0**
+
+Optional requirements:
+
+* ``h5py``, **>=2.8.0**
+* ``pandas``, **>=0.17.0**
+* ``sqlalchemy``, **>=0.8.4**
+* ``jsonpickle``, **>=0.9.6**
+* ``cloudpickle``, **>=0.5.2**
+
+
 More Information
 ----------------
 Probably the best way to get started is to look at the documentation at

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To include optional archive backends, such as HDF5 and SQL, in the install::
 
     $ pip install klepto[archives]
 
-To include optional serializers, such as jsonpickle, in the install::
+To include optional serializers, such as ``jsonpickle``, in the install::
 
     $ pip install klepto[crypto]
 

--- a/klepto/__init__.py
+++ b/klepto/__init__.py
@@ -6,33 +6,215 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/klepto/blob/master/LICENSE
 
-# get version numbers, license, and long description
-try:
-    from .info import this_version as __version__
-    from .info import readme as __doc__, license as __license__
-except ImportError:
-    msg = """First run 'python setup.py build' to build klepto."""
-    raise ImportError(msg)
-
+# author, version, license, and long description
+__version__ = '0.2.2.dev0'
 __author__ = 'Mike McKerns'
 
 __doc__ = """
-""" + __doc__
+-------------------------------------------------------
+klepto: persistent caching to memory, disk, or database
+-------------------------------------------------------
+
+About Klepto
+============
+
+``klepto`` extends python's ``lru_cache`` to utilize different keymaps and
+alternate caching algorithms, such as ``lfu_cache`` and ``mru_cache``.
+While caching is meant for fast access to saved results, ``klepto`` also
+has archiving capabilities, for longer-term storage. ``klepto`` uses a
+simple dictionary-sytle interface for all caches and archives, and all
+caches can be applied to any python function as a decorator. Keymaps
+are algorithms for converting a function's input signature to a unique
+dictionary, where the function's results are the dictionary value.
+Thus for ``y = f(x)``, ``y`` will be stored in ``cache[x]`` (e.g. ``{x:y}``).
+
+``klepto`` provides both standard and *"safe"* caching, where *"safe"* caches
+are slower but can recover from hashing errors. ``klepto`` is intended
+to be used for distributed and parallel computing, where several of
+the keymaps serialize the stored objects. Caches and archives are
+intended to be read/write accessible from different threads and
+processes. ``klepto`` enables a user to decorate a function, save the
+results to a file or database archive, close the interpreter,
+start a new session, and reload the function and it's cache.
+
+``klepto`` is part of ``pathos``, a python framework for heterogeneous computing.
+``klepto`` is in active development, so any user feedback, bug reports, comments,
+or suggestions are highly appreciated.  A list of issues is located at https://github.com/uqfoundation/klepto/issues, with a legacy list maintained at https://uqfoundation.github.io/project/pathos/query.
+
+
+Major Features
+==============
+
+``klepto`` has standard and *"safe"* variants of the following:
+
+    - ``lfu_cache`` - the least-frequently-used caching algorithm
+    - ``lru_cache`` - the least-recently-used caching algorithm
+    - ``mru_cache`` - the most-recently-used caching algorithm
+    - ``rr_cache`` - the random-replacement caching algorithm
+    - ``no_cache`` - a dummy caching interface to archiving
+    - ``inf_cache`` - an infinitely-growing cache
+
+``klepto`` has the following archive types:
+
+    - ``file_archive`` - a dictionary-style interface to a file
+    - ``dir_archive`` - a dictionary-style interface to a folder of files
+    - ``sqltable_archive`` - a dictionary-style interface to a sql database table
+    - ``sql_archive`` - a dictionary-style interface to a sql database
+    - ``hdfdir_archive`` - a dictionary-style interface to a folder of hdf5 files
+    - ``hdf_archive`` - a dictionary-style interface to a hdf5 file
+    - ``dict_archive`` - a dictionary with an archive interface
+    - ``null_archive`` - a dictionary-style interface to a dummy archive 
+
+``klepto`` provides the following keymaps:
+
+    - ``keymap`` - keys are raw python objects
+    - ``hashmap`` - keys are a hash for the python object
+    - ``stringmap`` - keys are the python object cast as a string
+    - ``picklemap`` - keys are the serialized python object
+
+``klepto`` also includes a few useful decorators providing:
+
+    - simple, shallow, or deep rounding of function arguments
+    - cryptographic key generation, with masking of selected arguments
+
+
+Current Release
+===============
+
+The latest released version of ``klepto`` is available from:
+
+    https://pypi.org/project/klepto
+
+``klepto`` is distributed under a 3-clause BSD license.
+
+
+Development Version 
+===================
+
+You can get the latest development version with all the shiny new features at:
+
+    https://github.com/uqfoundation
+
+If you have a new contribution, please submit a pull request.
+
+
+Installation
+============
+
+``klepto`` can be installed with ``pip``::
+
+    $ pip install klepto
+
+To include optional archive backends, such as HDF5 and SQL, in the install::
+
+    $ pip install klepto[archives]
+
+To include optional serializers, such as jsonpickle, in the install::
+
+    $ pip install klepto[crypto]
+
+
+Requirements
+============
+
+``klepto`` requires:
+
+    - ``python`` (or ``pypy``), **==2.7** or **>=3.7**
+    - ``setuptools``, **>=42**
+    - ``wheel``, **>=0.1**
+    - ``dill``, **>=0.3.4**
+    - ``pox``, **>=0.3.0**
+
+Optional requirements:
+
+    - ``h5py``, **>=2.8.0**
+    - ``pandas``, **>=0.17.0**
+    - ``sqlalchemy``, **>=0.8.4**
+    - ``jsonpickle``, **>=0.9.6**
+    - ``cloudpickle``, **>=0.5.2**
+
+
+More Information
+================
+
+Probably the best way to get started is to look at the documentation at
+http://klepto.rtfd.io. Also see ``klepto.tests`` for a set of scripts that
+test the caching and archiving functionalities in ``klepto``.
+You can run the test suite with ``python -m klepto.tests``.  The
+source code is also generally well documented, so further questions may
+be resolved by inspecting the code itself. Please feel free to submit
+a ticket on github, or ask a question on stackoverflow (**@Mike McKerns**).
+If you would like to share how you use ``klepto`` in your work, please send
+an email (to **mmckerns at uqfoundation dot org**).
+
+
+Citation
+========
+
+If you use ``klepto`` to do research that leads to publication, we ask that you
+acknowledge use of ``klepto`` by citing the following in your publication::
+
+    Michael McKerns and Michael Aivazis,
+    "pathos: a framework for heterogeneous computing", 2010- ;
+    https://uqfoundation.github.io/project/pathos
+
+Please see https://uqfoundation.github.io/project/pathos or
+further information.
+
+"""
 
 __license__ = """
-""" + __license__
+Copyright (c) 2004-2016 California Institute of Technology.
+Copyright (c) 2016-2022 The Uncertainty Quantification Foundation.
+All rights reserved.
 
+This software is available subject to the conditions and terms laid
+out below. By downloading and using this software you are agreeing
+to the following conditions.
 
-from ._cache import no_cache, inf_cache, lfu_cache, \
-                    lru_cache, mru_cache, rr_cache
-from ._inspect import signature, isvalid, validate, \
-                      keygen, strip_markup, NULL, _keygen
-from . import rounding
-from . import safe
-from . import archives
-from . import keymaps
-from . import tools
-from . import crypto
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met::
+
+    - Redistribution of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistribution in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentations and/or other materials provided with the distribution.
+
+    - Neither the names of the copyright holders nor the names of any of
+      the contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+try:
+    # This is a hack to import a minimal package for the build process
+    __KLEPTO_SETUP__
+except NameError:
+    from ._cache import no_cache, inf_cache, lfu_cache, \
+                        lru_cache, mru_cache, rr_cache
+    from ._inspect import signature, isvalid, validate, \
+                          keygen, strip_markup, NULL, _keygen
+    from . import rounding
+    from . import safe
+    from . import archives
+    from . import keymaps
+    from . import tools
+    from . import crypto
 
 
 def license():

--- a/klepto/__init__.py
+++ b/klepto/__init__.py
@@ -201,20 +201,16 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
-try:
-    # This is a hack to import a minimal package for the build process
-    __KLEPTO_SETUP__
-except NameError:
-    from ._cache import no_cache, inf_cache, lfu_cache, \
-                        lru_cache, mru_cache, rr_cache
-    from ._inspect import signature, isvalid, validate, \
-                          keygen, strip_markup, NULL, _keygen
-    from . import rounding
-    from . import safe
-    from . import archives
-    from . import keymaps
-    from . import tools
-    from . import crypto
+from ._cache import no_cache, inf_cache, lfu_cache, \
+                    lru_cache, mru_cache, rr_cache
+from ._inspect import signature, isvalid, validate, \
+                      keygen, strip_markup, NULL, _keygen
+from . import rounding
+from . import safe
+from . import archives
+from . import keymaps
+from . import tools
+from . import crypto
 
 
 def license():

--- a/klepto/__init__.py
+++ b/klepto/__init__.py
@@ -109,7 +109,7 @@ To include optional archive backends, such as HDF5 and SQL, in the install::
 
     $ pip install klepto[archives]
 
-To include optional serializers, such as jsonpickle, in the install::
+To include optional serializers, such as ``jsonpickle``, in the install::
 
     $ pip install klepto[crypto]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+# Further build requirements come from setup.py via the PEP 517 interface
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,7 @@
 [egg_info]
 tag_build = .dev0
-#tag_svn_revision = yes
-#tag_date = yes
+
+[bdist_wheel]
+#universal = 1
+#python-tag = py3
+#plat-name = manylinux1_x86_64

--- a/setup.py
+++ b/setup.py
@@ -17,21 +17,42 @@ elif (3, 0) <= sys.version_info < (3, 7):
 if unsupported:
     raise ValueError(unsupported)
 
+# get distribution meta info
+here = os.path.abspath(os.path.dirname(__file__))
+meta_fh = open(os.path.join(here, 'klepto/__init__.py'))
 try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
-
-# This is a hack to import a minimal package for the build process
-builtins.__KLEPTO_SETUP__ = True
-sys.path.append(os.path.abspath(os.path.curdir))
-import klepto
+    meta = {}
+    for line in meta_fh:
+        if line.startswith('__version__'):
+            VERSION = line.split()[-1].strip("'").strip('"')
+            break
+    meta['VERSION'] = VERSION
+    for line in meta_fh:
+        if line.startswith('__author__'):
+            AUTHOR = line.split(' = ')[-1].strip().strip("'").strip('"')
+            break
+    meta['AUTHOR'] = AUTHOR
+    LONG_DOC = ""
+    DOC_STOP = "FAKE_STOP_12345"
+    for line in meta_fh:
+        if LONG_DOC:
+            if line.startswith(DOC_STOP):
+                LONG_DOC += DOC_STOP.rstrip()
+                break
+            else:
+                LONG_DOC += line
+        elif line.startswith('__doc__'):
+            DOC_STOP = line.split(' = ')[-1]
+            LONG_DOC += DOC_STOP
+    meta['LONG_DOC'] = LONG_DOC
+finally:
+    meta_fh.close()
 
 # get version numbers, long_description, etc
-AUTHOR = klepto.__author__
-VERSION = klepto.__version__
-LONG_DOC = klepto.__doc__ #FIXME: near-duplicate of README.md
-#LICENSE = klepto.__license__ #FIXME: duplicate of LICENSE
+AUTHOR = meta['AUTHOR']
+VERSION = meta['VERSION']
+LONG_DOC = meta['LONG_DOC'] #FIXME: near-duplicate of README.md
+#LICENSE = meta['LICENSE'] #FIXME: duplicate of LICENSE
 AUTHOR_EMAIL = 'mmckerns@uqfoundation.org'
 
 # check if setuptools is available

--- a/setup.py
+++ b/setup.py
@@ -17,300 +17,123 @@ elif (3, 0) <= sys.version_info < (3, 7):
 if unsupported:
     raise ValueError(unsupported)
 
-# set version numbers
-stable_version = '0.2.1'
-target_version = '0.2.2'
-is_release = stable_version == target_version
-
-# check if easy_install is available
 try:
-#   import __force_distutils__ #XXX: uncomment to force use of distutills
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
+# This is a hack to import a minimal package for the build process
+builtins.__KLEPTO_SETUP__ = True
+sys.path.append(os.path.abspath(os.path.curdir))
+import klepto
+
+# get version numbers, long_description, etc
+AUTHOR = klepto.__author__
+VERSION = klepto.__version__
+LONG_DOC = klepto.__doc__ #FIXME: near-duplicate of README.md
+#LICENSE = klepto.__license__ #FIXME: duplicate of LICENSE
+AUTHOR_EMAIL = 'mmckerns@uqfoundation.org'
+
+# check if setuptools is available
+try:
     from setuptools import setup
+    from setuptools.dist import Distribution
     has_setuptools = True
 except ImportError:
     from distutils.core import setup
+    Distribution = object
     has_setuptools = False
 
-# generate version number
-if os.path.exists('klepto/info.py'):
-    # is a source distribution, so use existing version
-    os.chdir('klepto')
-    with open('info.py','r') as f:
-        f.readline() # header
-        this_version = f.readline().split()[-1].strip("'")
-    os.chdir('..')
-elif stable_version == target_version:
-    # we are building a stable release
-    this_version = target_version
-else:
-    # we are building a distribution
-    this_version = target_version + '.dev0'
-    if is_release:
-        from datetime import date
-        today = "".join(date.isoformat(date.today()).split('-'))
-        this_version += "-" + today
-
-# get the license info
-with open('LICENSE') as file:
-    license_text = file.read()
-
-# generate the readme text
-long_description = \
-"""-------------------------------------------------------
-klepto: persistent caching to memory, disk, or database
--------------------------------------------------------
-
-About Klepto
-============
-
-``klepto`` extends python's ``lru_cache`` to utilize different keymaps and
-alternate caching algorithms, such as ``lfu_cache`` and ``mru_cache``.
-While caching is meant for fast access to saved results, ``klepto`` also
-has archiving capabilities, for longer-term storage. ``klepto`` uses a
-simple dictionary-sytle interface for all caches and archives, and all
-caches can be applied to any python function as a decorator. Keymaps
-are algorithms for converting a function's input signature to a unique
-dictionary, where the function's results are the dictionary value.
-Thus for ``y = f(x)``, ``y`` will be stored in ``cache[x]`` (e.g. ``{x:y}``).
-
-``klepto`` provides both standard and *"safe"* caching, where *"safe"* caches
-are slower but can recover from hashing errors. ``klepto`` is intended
-to be used for distributed and parallel computing, where several of
-the keymaps serialize the stored objects. Caches and archives are
-intended to be read/write accessible from different threads and
-processes. ``klepto`` enables a user to decorate a function, save the
-results to a file or database archive, close the interpreter,
-start a new session, and reload the function and it's cache.
-
-``klepto`` is part of ``pathos``, a python framework for heterogeneous computing.
-``klepto`` is in active development, so any user feedback, bug reports, comments,
-or suggestions are highly appreciated.  A list of issues is located at https://github.com/uqfoundation/klepto/issues, with a legacy list maintained at https://uqfoundation.github.io/project/pathos/query.
-
-
-Major Features
-==============
-
-``klepto`` has standard and *"safe"* variants of the following:
-
-    - ``lfu_cache`` - the least-frequently-used caching algorithm
-    - ``lru_cache`` - the least-recently-used caching algorithm
-    - ``mru_cache`` - the most-recently-used caching algorithm
-    - ``rr_cache`` - the random-replacement caching algorithm
-    - ``no_cache`` - a dummy caching interface to archiving
-    - ``inf_cache`` - an infinitely-growing cache
-
-``klepto`` has the following archive types:
-
-    - ``file_archive`` - a dictionary-style interface to a file
-    - ``dir_archive`` - a dictionary-style interface to a folder of files
-    - ``sqltable_archive`` - a dictionary-style interface to a sql database table
-    - ``sql_archive`` - a dictionary-style interface to a sql database
-    - ``hdfdir_archive`` - a dictionary-style interface to a folder of hdf5 files
-    - ``hdf_archive`` - a dictionary-style interface to a hdf5 file
-    - ``dict_archive`` - a dictionary with an archive interface
-    - ``null_archive`` - a dictionary-style interface to a dummy archive 
-
-``klepto`` provides the following keymaps:
-
-    - ``keymap`` - keys are raw python objects
-    - ``hashmap`` - keys are a hash for the python object
-    - ``stringmap`` - keys are the python object cast as a string
-    - ``picklemap`` - keys are the serialized python object
-
-``klepto`` also includes a few useful decorators providing:
-
-    - simple, shallow, or deep rounding of function arguments
-    - cryptographic key generation, with masking of selected arguments
-
-
-Current Release
-===============
-
-This documentation is for version ``klepto-%(thisver)s``.
-
-The latest released version of ``klepto`` is available from:
-
-    https://pypi.org/project/klepto
-
-``klepto`` is distributed under a 3-clause BSD license.
-
-    >>> import klepto
-    >>> klepto.license()
-
-
-Development Version 
-===================
-
-You can get the latest development version with all the shiny new features at:
-
-    https://github.com/uqfoundation
-
-If you have a new contribution, please submit a pull request.
-
-
-Installation
-============
-
-``klepto`` is packaged to install from source, so you must
-download the tarball, unzip, and run the installer::
-
-    [download]
-    $ tar -xvzf klepto-%(relver)s.tar.gz
-    $ cd klepto-%(relver)s
-    $ python setup py build
-    $ python setup py install
-
-You will be warned of any missing dependencies and/or settings
-after you run the "build" step above. 
-
-Alternately, ``klepto`` can be installed with ``pip`` or ``easy_install``::
-
-    $ pip install klepto
-
-
-Requirements
-============
-
-``klepto`` requires:
-
-    - ``python`` (or ``pypy``), **version == 2.7** or **version >= 3.7**
-    - ``dill``, **version >= 0.3.4**
-    - ``pox``, **version >= 0.3.0**
-
-Optional requirements:
-
-    - ``h5py``, **version >= 2.8.0**
-    - ``pandas``, **version >= 0.17.0**
-    - ``sqlalchemy``, **version >= 0.8.4**
-    - ``jsonpickle``, **version >= 0.9.6**
-    - ``cloudpickle``, **version >= 0.5.2**
-    - ``setuptools``, **version >= 40.6.0**
-
-
-More Information
-================
-
-Probably the best way to get started is to look at the documentation at
-http://klepto.rtfd.io. Also see ``klepto.tests`` for a set of scripts that
-test the caching and archiving functionalities in ``klepto``.
-You can run the test suite with ``python -m klepto.tests``.  The
-source code is also generally well documented, so further questions may
-be resolved by inspecting the code itself. Please feel free to submit
-a ticket on github, or ask a question on stackoverflow (**@Mike McKerns**).
-If you would like to share how you use ``klepto`` in your work, please send
-an email (to **mmckerns at uqfoundation dot org**).
-
-
-Citation
-========
-
-If you use ``klepto`` to do research that leads to publication, we ask that you
-acknowledge use of ``klepto`` by citing the following in your publication::
-
-    Michael McKerns and Michael Aivazis,
-    "pathos: a framework for heterogeneous computing", 2010- ;
-    https://uqfoundation.github.io/project/pathos
-
-Please see https://uqfoundation.github.io/project/pathos or
-further information.
-
-""" % {'relver' : stable_version, 'thisver' : this_version}
-
-# write readme file
-with open('README', 'w') as file:
-    file.write(long_description)
-
-# generate 'info' file contents
-def write_info_py(filename='klepto/info.py'):
-    contents = """# THIS FILE GENERATED FROM SETUP.PY
-this_version = '%(this_version)s'
-stable_version = '%(stable_version)s'
-readme = '''%(long_description)s'''
-license = '''%(license_text)s'''
-"""
-    with open(filename, 'w') as file:
-        file.write(contents % {'this_version' : this_version,
-                               'stable_version' : stable_version,
-                               'long_description' : long_description,
-                               'license_text' : license_text })
-    return
-
-# write info file
-write_info_py()
-
 # build the 'setup' call
-setup_code = """
-setup(name='klepto',
-      version='%s',
-      description='persistent caching to memory, disk, or database',
-      long_description = '''%s''',
-      author = 'Mike McKerns',
-      maintainer = 'Mike McKerns',
-      license = '3-clause BSD',
-      platforms = ['Linux', 'Windows', 'Mac'],
-      url = 'https://github.com/uqfoundation/klepto',
-      download_url = 'https://github.com/uqfoundation/klepto/releases/download/klepto-%s/klepto-%s.tar.gz',
-      python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*',
-      classifiers = ['Development Status :: 5 - Production/Stable',
-                     'Intended Audience :: Developers',
-                     'Intended Audience :: Science/Research',
-                     'License :: OSI Approved :: BSD License',
-                     'Programming Language :: Python :: 2',
-                     'Programming Language :: Python :: 2.7',
-                     'Programming Language :: Python :: 3',
-                     'Programming Language :: Python :: 3.7',
-                     'Programming Language :: Python :: 3.8',
-                     'Programming Language :: Python :: 3.9',
-                     'Programming Language :: Python :: 3.10',
-                     'Programming Language :: Python :: Implementation :: PyPy',
-                     'Topic :: Database',
-                     'Topic :: Scientific/Engineering',
-                     'Topic :: Software Development'],
+setup_kwds = dict(
+    name='klepto',
+    version=VERSION,
+    description='persistent caching to memory, disk, or database',
+    long_description = LONG_DOC,
+    author = AUTHOR,
+    author_email = AUTHOR_EMAIL,
+    maintainer = AUTHOR,
+    maintainer_email = AUTHOR_EMAIL,
+    license = '3-clause BSD',
+    platforms = ['Linux', 'Windows', 'Mac'],
+    url = 'https://github.com/uqfoundation/klepto',
+    download_url = 'https://pypi.org/project/klepto/#files',
+    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*',
+    classifiers = ['Development Status :: 5 - Production/Stable',
+                   'Intended Audience :: Developers',
+                   'Intended Audience :: Science/Research',
+                   'License :: OSI Approved :: BSD License',
+                   'Programming Language :: Python :: 2',
+                   'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3',
+                   'Programming Language :: Python :: 3.7',
+                   'Programming Language :: Python :: 3.8',
+                   'Programming Language :: Python :: 3.9',
+                   'Programming Language :: Python :: 3.10',
+                   'Programming Language :: Python :: Implementation :: PyPy',
+                   'Topic :: Database',
+                   'Topic :: Scientific/Engineering',
+                   'Topic :: Software Development'],
+    packages = ['klepto','klepto.tests'],
+    package_dir = {'klepto':'klepto', 'klepto.tests':'tests'},
+)
 
-      packages = ['klepto','klepto.tests'],
-      package_dir = {'klepto':'klepto','klepto.tests':'tests'},
-""" % (target_version, long_description, stable_version, stable_version)
+# force python-, abi-, and platform-specific naming of bdist_wheel
+class BinaryDistribution(Distribution):
+    """Distribution which forces a binary package with platform name"""
+    def has_ext_modules(foo):
+        return True
 
-# add dependencies
+# define dependencies
 sysversion = sys.version_info[:3]
-dill_version = '>=0.3.4'
-pox_version = '>=0.3.0'
-sqlalchemy_version = '>=0.8.4'
-h5py_version = '>=2.8.0'
+dill_version = 'dill>=0.3.4'
+pox_version = 'pox>=0.3.0'
+jsonpickle_version = 'jsonpickle>=0.9.6'
+cloudpickle_version = 'cloudpickle>=0.5.2'
+sqlalchemy_version = 'sqlalchemy>=0.8.4'
+h5py_version = 'h5py>=2.8.0'
 if sysversion < (3,5,3):
-    pandas_version = '>=0.17.0, <0.25.0'
+    pandas_version = 'pandas>=0.17.0, <0.25.0'
 elif sysversion < (3,6,1):
-    pandas_version = '>=0.17.0, <1.0.0'
+    pandas_version = 'pandas>=0.17.0, <1.0.0'
 elif sysversion < (3,7,1):
-    pandas_version = '>=0.17.0, <1.2.0'
+    pandas_version = 'pandas>=0.17.0, <1.2.0'
 else:
-    pandas_version = '>=0.17.0'
+    pandas_version = 'pandas>=0.17.0'
+# add dependencies
+depend = [pox_version, dill_version]
+extras = {'archives': [h5py_version, sqlalchemy_version, pandas_version], 'crypto': [jsonpickle_version, cloudpickle_version]}
+# update setup kwds
 if has_setuptools:
-    setup_code += """
-      zip_safe=False,
-      install_requires = ['dill%s','pox%s'],
-      extras_require = {'archives': ['h5py%s','sqlalchemy%s','pandas%s']},
-""" % (dill_version, pox_version, h5py_version, sqlalchemy_version, pandas_version)
+    setup_kwds.update(
+        zip_safe=False,
+        # distclass=BinaryDistribution,
+        install_requires=depend,
+        extras_require=extras,
+    )
 
-# add the scripts, and close 'setup' call
-setup_code += """
-      )
-"""
-
-# exec the 'setup' code
-exec(setup_code)
+# call setup
+setup(**setup_kwds)
 
 # if dependencies are missing, print a warning
 try:
     import dill
     import pox
-   #import sqlalchemy
+    #import jsonpickle
+    #import cloudpickle
+    #import sqlalchemy
+    #import h5py
+    #import pandas
 except ImportError:
     print ("\n***********************************************************")
     print ("WARNING: One of the following dependencies is unresolved:")
-    print ("    dill %s" % dill_version)
-    print ("    pox %s" % pox_version)
-   #print ("    sqlalchemy %s" % sqlalchemy_version)
+    print ("    %s" % dill_version)
+    print ("    %s" % pox_version)
+    print ("    %s (optional)" % jsonpickle_version)
+    print ("    %s (optional)" % cloudpickle_version)
+    print ("    %s (optional)" % sqlalchemy_version)
+    print ("    %s (optional)" % h5py_version)
+    print ("    %s (optional)" % pandas_version)
     print ("***********************************************************\n")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,7 @@ deps =
 whitelist_externals =
     bash
 commands =
-    {envpython} setup.py build
-    {envpython} setup.py install
+    {envpython} -m pip install .
     bash -c "failed=0; for test in tests/__main__.py; do echo $test; \
              {envpython} $test || failed=1; done; exit $failed"
     {envpython} tests/cleanup_basic.py


### PR DESCRIPTION
remove `exec` from setup.py; enable support for in-place builds and pep517-compliant builds

Fixes #72 