### PR TITLE
define html_theme as rtd workaround

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,6 +131,8 @@ if not on_rtd:
    #import sphinx_rtd_theme
    #html_theme = 'sphinx_rtd_theme'
    #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+else:
+    html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Summary
define `html_theme` when on RTD as a workaround for recent breakage in building docs on RTD

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.