### PR TITLE
type check with Integral not int

### DIFF
--- a/klepto/_inspect.py
+++ b/klepto/_inspect.py
@@ -421,9 +421,10 @@ def _keygen(func, ignored, *args, **kwds):
         user_kwds = kwds.copy()
 
     # decompose the list of things to ignore to names and indicies
-    if isinstance(ignored, (str,int)): ignored = [ignored]
-    index_to_ignore = set(i for i in ignored if isinstance(i,int))
-    names_to_ignore = set(i for i in ignored if isinstance(i,str))
+    from numbers import Integral
+    if isinstance(ignored, (str, Integral)): ignored = [ignored]
+    index_to_ignore = set(i for i in ignored if isinstance(i, Integral))
+    names_to_ignore = set(i for i in ignored if isinstance(i, str))
 
     # if ignore self, remove self instead of NULL it
     if inspect.isfunction(func):

--- a/klepto/keymaps.py
+++ b/klepto/keymaps.py
@@ -105,9 +105,9 @@ class keymap(object):
 
         # some rare kwds that allow keymap customization
         try:
-            self._fasttypes = (int,str,bytes,frozenset,type(None))
+            self._fasttypes = (int,str,bytes,frozenset,type(None)) # int64?
         except NameError:
-            self._fasttypes = (int,str,frozenset,type(None))
+            self._fasttypes = (int,str,frozenset,type(None)) # int64?
         self._fasttypes = kwds.pop('fasttypes', set(self._fasttypes))
         self._sorted = kwds.pop('sorted', sorted)
         self._tuple = kwds.pop('tuple', tuple)


### PR DESCRIPTION
## Summary
replace check for `isinstance` of `int` with `Integral`

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.