### PR TITLE
add initial support for python 3.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ matrix:
         - python: '3.12'
           env:
 
-        - python: '3.13-dev'
+        - python: '3.13'
+          env:
+
+        - python: '3.14-dev'
           env:
             - DILL="master"
 
@@ -36,6 +39,7 @@ matrix:
           env:
 
     allow_failures:
+        - python: '3.14-dev' # CI missing
         - python: 'pypy3.10-7.3.17' # CI missing
     fast_finish: true
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
 # Packages required to build docs
 # dependencies pinned as:
-# https://github.com/readthedocs/readthedocs.org/blob/d3606da9907bb4cd933abcf71c7bab9eb20435cd/requirements/docs.txt
+# https://github.com/readthedocs/readthedocs.org/blob/71a82c94adbacf87b4630288f91f1a56e05f54f2/requirements/docs.txt
 
 alabaster==0.7.16
 anyio==4.4.0
 babel==2.15.0
-certifi==2024.7.4
+certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
@@ -47,10 +47,11 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
+phinxext-opengraph==0.9.1
 starlette==0.37.2
 tomli==2.0.1
 typing-extensions==4.12.1
-urllib3==2.2.2
+urllib3==2.2.1
 uvicorn==0.30.0
 watchfiles==0.22.0
 websockets==12.0

--- a/klepto/tests/test_chaining.py
+++ b/klepto/tests/test_chaining.py
@@ -16,7 +16,9 @@ hp = p + h
 def test_chaining():
     assert p(1) == pickle(1, serializer='dill')
     assert h(1) == 'c4ca4238a0b923820dcc509a6f75849b'
-    if sys.version_info[1] < 8:
+    if sys.hexversion > 0x30e00a0: #XXX: 3.14.0a1 different than prior
+        assert hp(1) == 'c7483051dc5df58359faa78d4593981c'
+    elif sys.version_info[1] < 8:
         assert hp(1) == 'a2ed37e4f2f0ccf8be170d8c31c711b2'
     else: #XXX: because 3.x returns b'', 2.x returns '', and 3.8 is weird
         assert hp(1) == 'bfac8a39dc4b0d616a0805a453698556'

--- a/setup.py
+++ b/setup.py
@@ -128,9 +128,3 @@ except ImportError:
     print ("    %s (optional)" % h5py_version)
     print ("    %s (optional)" % pandas_version)
     print ("***********************************************************\n")
-
-
-if __name__=='__main__':
-    pass
-
-# end of file

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py311
     py312
     py313
+    py314
     pypy38
     pypy39
     pypy310


### PR DESCRIPTION
## Summary
add initial support for python 3.14
Fixes: #140 

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added rationale for any breakage of backwards compatibility.
